### PR TITLE
Add Makefile compatible with DuckDB-Wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,29 @@ format:
 
 update:
 	git submodule update --remote --merge
+
+VCPKG_EMSDK_FLAGS=-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(EMSDK)/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+WASM_COMPILE_TIME_COMMON_FLAGS=-DWASM_LOADABLE_EXTENSIONS=1 -DBUILD_EXTENSIONS_ONLY=1 -DSKIP_EXTENSIONS="parquet;json" $(VCPKG_EMSDK_FLAGS)
+WASM_CXX_MVP_FLAGS=
+WASM_CXX_EH_FLAGS=$(WASM_CXX_MVP_FLAGS) -fwasm-exceptions -DWEBDB_FAST_EXCEPTIONS=1
+WASM_CXX_THREADS_FLAGS=$(WASM_COMPILE_TIME_EH_FLAGS) -DWITH_WASM_THREADS=1 -DWITH_WASM_SIMD=1 -DWITH_WASM_BULK_MEMORY=1
+WASM_LINK_TIME_FLAGS=../../third_party/re2/libduckdb_re2.a -sSIDE_MODULE=2 -sEXPORTED_FUNCTIONS="_psql_init,_psql_version"
+EXT_NAME=psql
+
+wasm_mvp:
+	mkdir -p build/wasm_mvp
+	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_mvp -DCMAKE_CXX_FLAGS="$(WASM_CXX_MVP_FLAGS) -DDUCKDB_CUSTOM_PLATFORM=wasm_mvp" -S duckdb
+	emmake make -j8 -Cbuild/wasm_mvp
+	cd build/wasm_mvp/extension/${EXT_NAME} && emcc $f -o ../../${EXT_NAME}.duckdb_extension.wasm -O3 ${EXT_NAME}.duckdb_extension $(WASM_LINK_TIME_FLAGS)
+
+wasm_eh:
+	mkdir -p build/wasm_eh
+	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_eh -DCMAKE_CXX_FLAGS="$(WASM_CXX_EH_FLAGS) -DDUCKDB_CUSTOM_PLATFORM=wasm_eh" -S duckdb
+	emmake make -j8 -Cbuild/wasm_eh
+	cd build/wasm_eh/extension/${EXT_NAME} && emcc $f -o ../../${EXT_NAME}.duckdb_extension.wasm -O3 ${EXT_NAME}.duckdb_extension $(WASM_LINK_TIME_FLAGS)
+
+wasm_threads:
+	mkdir -p ./build/wasm_threads
+	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_threads -DCMAKE_CXX_FLAGS="$(WASM_CXX_THREADS_FLAGS) -DDUCKDB_CUSTOM_PLATFORM=wasm_threads" -S duckdb
+	emmake make -j8 -Cbuild/wasm_threads
+	cd build/wasm_threads/extension/${EXT_NAME} && emcc $f -o ../../${EXT_NAME}.duckdb_extension.wasm -O3 ${EXT_NAME}.duckdb_extension $(WASM_LINK_TIME_FLAGS)


### PR DESCRIPTION
This changes make it possible to compile (once the relevant tools are installed) duckdb-psql to duckdb-wasm.

Example deployment of the duckdb-wasm web-shell (with signature checks disabled): https://carlopi.github.io/duckdb-wasm-unsigned/#queries=v0,LOAD-'https%3A%2F%2Fcarlopi.github.io%2Fduckdb%20wasm%20unsigned%2Fthird_party_extensions%2Fpsql.duckdb_extension.wasm'~,from-'https%3A%2F%2Fraw.githubusercontent.com%2Fywelsch%2Fduckdb%20psql%2Fmain%2Fexample%2Finvoices.csv'-%7C-order-by-total-DESC-%7C-limit-10~

I will do a next pass and figure out deployment (ideally on github pages).